### PR TITLE
Make RSSI for creatures a bit sticky

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,6 +1,8 @@
 [platformio]
 # These default envs are built when running `pio run`.
 # Note that GitHub Actions use a different list in `jazzlights.yml`.
+core_dir = c:\.platformio
+workspace_dir = c:\.pio
 default_envs =
   vest
   vest_dev
@@ -579,7 +581,7 @@ build_flags =
 extends = env:_idf5
 board = esp32-c6-devkitm-1
 upload_speed = 1500000
-upload_port = hwgrep://^/dev/cu\.(usb|)modem\d{3,5}$
+upload_port = COM7
 board_build.partitions = atom_matrix_partition_table.csv
 build_flags =
   ${env:_idf5.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -674,3 +674,12 @@ build_flags =
   -std=c++20
   -DJL_CONFIG=NONE
   -DJL_CONTROLLER=NATIVE
+
+# Custom config for Creature::ChickM for now
+[env:creature_c6_chickm]
+extends = env:creature_c6
+upload_port = COM8
+monitor_port = ${this.upload_port}
+build_flags =
+  ${env:creature.build_flags}
+  -DJL_BRIGHTNESS_CUSTOM=96

--- a/platformio.ini
+++ b/platformio.ini
@@ -681,5 +681,5 @@ extends = env:creature_c6
 upload_port = COM8
 monitor_port = ${this.upload_port}
 build_flags =
-  ${env:creature.build_flags}
+  ${env:creature_c6.build_flags}
   -DJL_BRIGHTNESS_CUSTOM=96

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,8 +1,6 @@
 [platformio]
 # These default envs are built when running `pio run`.
 # Note that GitHub Actions use a different list in `jazzlights.yml`.
-core_dir = c:\.platformio
-workspace_dir = c:\.pio
 default_envs =
   vest
   vest_dev
@@ -581,7 +579,7 @@ build_flags =
 extends = env:_idf5
 board = esp32-c6-devkitm-1
 upload_speed = 1500000
-upload_port = COM7
+upload_port = hwgrep://^/dev/cu\.(usb|)modem\d{4,5}$
 board_build.partitions = atom_matrix_partition_table.csv
 build_flags =
   ${env:_idf5.build_flags}

--- a/src/jazzlights/effect/creatures.cpp
+++ b/src/jazzlights/effect/creatures.cpp
@@ -4,6 +4,18 @@
 
 #include <esp_mac.h>
 
+namespace {
+constexpr int kRssiDecayDelayMs = 3000;  // Decay after 3s of inactivity.
+constexpr int kRssiDecayFactor = 5;      // Decay RSSI by 5dBm/s after delay.
+// Consider creatures far away if no nearby RSSI within 3 second.
+constexpr int kNearbyCreatureTimeoutMs = 3000;
+
+constexpr uint8_t kCloseCreatureIntensityThresh = 25;  // 10% of max intensity.
+constexpr int kMinCreaturesForAParty = 3;              // Minimum number of creatures to trigger a party.
+
+constexpr int kMSecPerSec = 1000;  // Number of milliseconds in a second.
+}  // namespace
+
 namespace jazzlights {
 
 namespace {
@@ -80,8 +92,11 @@ void KnownCreatures::AddCreature(uint32_t color, Milliseconds lastHeard, int rss
         creature.lastHeard = lastHeard;
         creature.lastHeardRssi = rssi;
         creature.effectiveRssi = rssi;
-        creature.lastHeardNearby =
-            (CreatureIntensity(creature) >= Creatures::kCloseCreatureIntensityThresh) ? lastHeard : 0;
+        if (CreatureIntensity(creature) >= kCloseCreatureIntensityThresh) {
+          creature.lastHeardNearby = lastHeard;
+        } else {
+          creature.lastHeardLessNearby = lastHeard;
+        }
       }
       found = true;
       break;
@@ -93,8 +108,14 @@ void KnownCreatures::AddCreature(uint32_t color, Milliseconds lastHeard, int rss
     new_creature.lastHeard = lastHeard;
     new_creature.lastHeardRssi = rssi;
     new_creature.effectiveRssi = rssi;
-    new_creature.lastHeardNearby =
-        (CreatureIntensity(new_creature) >= Creatures::kCloseCreatureIntensityThresh) ? lastHeard : 0;
+    new_creature.isNearby = false;
+    if (CreatureIntensity(new_creature) >= kCloseCreatureIntensityThresh) {
+      new_creature.lastHeardNearby = lastHeard;
+      new_creature.lastHeardLessNearby = -1;
+    } else {
+      new_creature.lastHeardNearby = -1;
+      new_creature.lastHeardLessNearby = lastHeard;
+    }
     creatures_.push_back(new_creature);
   }
   std::sort(creatures_.begin(), creatures_.end(),
@@ -104,18 +125,23 @@ void KnownCreatures::AddCreature(uint32_t color, Milliseconds lastHeard, int rss
 void KnownCreatures::update() {
   Milliseconds currentTime = timeMillis();
   for (Creature& creature : creatures_) {
-    if (creature.lastHeard > 0 && currentTime - creature.lastHeard > KnownCreatures::kRssiDecayDelayMs) {
+    if (creature.lastHeard > 0 && currentTime - creature.lastHeard > kRssiDecayDelayMs) {
       // If we haven't heard from this creature in kRssiDecayDelayMs, decay the RSSI by kRssiDecayFactor dBm every
       // second.
       creature.effectiveRssi =
           creature.lastHeardRssi -
-          (KnownCreatures::kRssiDecayFactor * (currentTime - creature.lastHeard + KnownCreatures::kRssiDecayDelayMs)) /
-              1000;
-    } else {
-      creature.effectiveRssi = creature.lastHeardRssi;
+          (kRssiDecayFactor * (currentTime - creature.lastHeard - kRssiDecayDelayMs)) / kMSecPerSec;
+      creature.isNearby = false;  // Non responsive creatures are not nearby.
+      return;
     }
-    if (CreatureIntensity(creature) >= Creatures::kCloseCreatureIntensityThresh) {
-      creature.lastHeardNearby = creature.lastHeard;
+    if (creature.lastHeardNearby > 0 && creature.isNearby &&
+        currentTime - creature.lastHeardNearby > kNearbyCreatureTimeoutMs) {
+      // If creature hasn't been close for kNearbyCreatureTimeoutMs, unstick the nearby flag.
+      creature.isNearby = false;
+    } else if (creature.lastHeardLessNearby > 0 && !creature.isNearby &&
+               currentTime - creature.lastHeardLessNearby > kNearbyCreatureTimeoutMs) {
+      // If creature hasn't been far away for kNearbyCreatureTimeoutMs, stick the nearby flag.
+      creature.isNearby = true;
     }
   }
 }
@@ -125,8 +151,10 @@ KnownCreatures::KnownCreatures() {
   ourselves.color = ThisCreatureColor();
   ourselves.lastHeard = -1;
   ourselves.lastHeardNearby = -1;
+  ourselves.lastHeardLessNearby = -1;
   ourselves.effectiveRssi = 20;
   ourselves.lastHeardRssi = 20;
+  ourselves.isNearby = true;
   creatures_.push_back(ourselves);
 }
 
@@ -150,18 +178,14 @@ void Creatures::rewind(const Frame& frame) const {
   KnownCreatures::Get()->update();
   const std::vector<Creature>& creatures = KnownCreatures::Get()->creatures();
   size_t num_creatures = creatures.size();
-  if (num_creatures > kMaxNumColors - 2) { num_creatures = kMaxNumColors - 2; }
+  if (num_creatures > kMaxNumCreatureColours - 2) { num_creatures = kMaxNumCreatureColours - 2; }
   uint32_t num_close_creatures = 0;
   for (size_t i = 0; i < num_creatures; i++) {
     // Compute the color for each known creature.
     const Creature& creature = creatures[i];
     uint8_t intensity = CreatureIntensity(creature);
     state(frame)->colors[i] = FadeColor(CRGB(creature.color), intensity);
-    if (creature.lastHeardNearby < 0 ||
-        timeMillis() - creature.lastHeardNearby < KnownCreatures::kNearbyCreatureTimeoutMs) {
-      // If the creature has been heard nearby in the last KnownCreatures::kNearbyCreatureTimeoutMs it is still close
-      num_close_creatures++;
-    }
+    if (creature.isNearby) { num_close_creatures++; }
   }
   state(frame)->colors[num_creatures] = CRGB::Black;
   state(frame)->colors[num_creatures + 1] = CRGB::Black;
@@ -172,7 +196,7 @@ void Creatures::rewind(const Frame& frame) const {
   // metric bidirectional. We can do that by having every node broadcast its list of known creatures and decayed RSSI
   // (or intensity) then we use a symmetric function (such as min or average) to decide when to put it in
   // num_close_creatures.
-  state(frame)->rainbow = num_close_creatures >= 3;
+  state(frame)->rainbow = num_close_creatures >= kMinCreaturesForAParty;
   state(frame)->initialHue = 256 * frame.time / 1667;
 }
 

--- a/src/jazzlights/effect/creatures.cpp
+++ b/src/jazzlights/effect/creatures.cpp
@@ -134,11 +134,11 @@ void KnownCreatures::update() {
       creature.isNearby = false;  // Non responsive creatures are not nearby.
       return;
     }
-    if (creature.lastHeardNearby > 0 && creature.isNearby &&
+    if (creature.lastHeardNearby >= 0 && creature.isNearby &&
         currentTime - creature.lastHeardNearby > kNearbyCreatureTimeoutMs) {
       // If creature hasn't been close for kNearbyCreatureTimeoutMs, unstick the nearby flag.
       creature.isNearby = false;
-    } else if (creature.lastHeardLessNearby > 0 && !creature.isNearby &&
+    } else if (creature.lastHeardLessNearby >= 0 && !creature.isNearby &&
                currentTime - creature.lastHeardLessNearby > kNearbyCreatureTimeoutMs) {
       // If creature hasn't been far away for kNearbyCreatureTimeoutMs, stick the nearby flag.
       creature.isNearby = true;

--- a/src/jazzlights/effect/creatures.cpp
+++ b/src/jazzlights/effect/creatures.cpp
@@ -109,13 +109,8 @@ void KnownCreatures::AddCreature(uint32_t color, Milliseconds lastHeard, int rss
     new_creature.lastHeardRssi = rssi;
     new_creature.effectiveRssi = rssi;
     new_creature.isNearby = false;
-    if (CreatureIntensity(new_creature) >= kCloseCreatureIntensityThresh) {
-      new_creature.lastHeardNearby = lastHeard;
-      new_creature.lastHeardLessNearby = -1;
-    } else {
-      new_creature.lastHeardNearby = -1;
-      new_creature.lastHeardLessNearby = lastHeard;
-    }
+    new_creature.lastHeardNearby = lastHeard;
+    new_creature.lastHeardLessNearby = lastHeard;
     creatures_.push_back(new_creature);
   }
   std::sort(creatures_.begin(), creatures_.end(),

--- a/src/jazzlights/effect/creatures.h
+++ b/src/jazzlights/effect/creatures.h
@@ -17,9 +17,8 @@ struct Creature {
   uint32_t color;
   Milliseconds lastHeard;
   int lastHeardRssi;
-  int rssi;
-  uint8_t intensity;
-  uint8_t intensityCounter;
+  int effectiveRssi;
+  Milliseconds lastHeardNearby;
 };
 
 class KnownCreatures {
@@ -37,11 +36,14 @@ class KnownCreatures {
   // Update all known creature states (decay RSSI, increment counters, etc)
   void update();
 
+  static constexpr int kRssiDecayDelayMs = 3000;  // Decay after 3s of inactivity
+  static constexpr int kRssiDecayFactor = 5;      // Decay RSSI by 5dBm/s after delay
+  // Consider creatures far away if no nearby RSSI within a second
+  static constexpr int kNearbyCreatureTimeoutMs = 3000;
+
  private:
   KnownCreatures();
   std::vector<Creature> creatures_;
-  static constexpr int kRssiDecayDelayMs = 3000;  // Decay after 3s of inactivity
-  static constexpr int kRssiDecayFactor = 5;      // Decay RSSI by 5dBm/s after delay
 };
 
 class Creatures : public Effect {
@@ -57,7 +59,7 @@ class Creatures : public Effect {
   void afterColors(const Frame& /*frame*/) const override;
   CRGB color(const Frame& frame, const Pixel& px) const override;
 
-  static constexpr uint8_t kCloseCreatureIntensityThresh = 100;
+  static constexpr uint8_t kCloseCreatureIntensityThresh = 75;
 
  private:
   static constexpr size_t kMaxNumColors = 256;

--- a/src/jazzlights/effect/creatures.h
+++ b/src/jazzlights/effect/creatures.h
@@ -18,8 +18,8 @@ struct Creature {
   Milliseconds lastHeard;
   int lastHeardRssi;
   int rssi;
-  uint8_t creatureIntensity;
-  uint8_t creatureIntensityCounter;
+  uint8_t intensity;
+  uint8_t intensityCounter;
 };
 
 class KnownCreatures {
@@ -35,13 +35,13 @@ class KnownCreatures {
   void ExpireOldEntries(Milliseconds currentTime);
   void AddCreature(uint32_t color, Milliseconds lastHeard, int rssi);
   // Update all known creature states (decay RSSI, increment counters, etc)
-  void update(void);
+  void update();
 
  private:
   KnownCreatures();
   std::vector<Creature> creatures_;
-  const int kRssiDecayDelayMs = 3000;  // Decay after 3s of inactivity
-  const int kRssiDecayFactor = 5;      // Decay RSSI by 5dBm/s after delay
+  static constexpr int kRssiDecayDelayMs = 3000;  // Decay after 3s of inactivity
+  static constexpr int kRssiDecayFactor = 5;      // Decay RSSI by 5dBm/s after delay
 };
 
 class Creatures : public Effect {
@@ -57,7 +57,7 @@ class Creatures : public Effect {
   void afterColors(const Frame& /*frame*/) const override;
   CRGB color(const Frame& frame, const Pixel& px) const override;
 
-  static const uint8_t kCloseCreatureIntensityThresh = 100;
+  static constexpr uint8_t kCloseCreatureIntensityThresh = 100;
 
  private:
   static constexpr size_t kMaxNumColors = 256;

--- a/src/jazzlights/layout/layout_data.cpp
+++ b/src/jazzlights/layout/layout_data.cpp
@@ -33,7 +33,7 @@ Matrix pixels(/*w=*/10, /*h=*/10);
 #endif  // XMAS_TREE
 
 #if JL_IS_CONFIG(CREATURE)
-Matrix pixels(/*w=*/30, /*h=*/1);
+Matrix pixels(/*w=*/32, /*h=*/1);
 #endif  // CREATURE
 
 }  // namespace

--- a/src/jazzlights/ui/ui_disabled.cpp
+++ b/src/jazzlights/ui/ui_disabled.cpp
@@ -12,6 +12,8 @@ static constexpr uint8_t kBrightness = 2;
 static constexpr uint8_t kBrightness = 16;
 #elif JL_IS_CONFIG(HAMMER)
 static constexpr uint8_t kBrightness = 255;
+#elif JL_IS_CONFIG(CREATURE)
+static constexpr uint8_t kBrightness = 96;
 #else
 static constexpr uint8_t kBrightness = 32;
 #endif

--- a/src/jazzlights/ui/ui_disabled.cpp
+++ b/src/jazzlights/ui/ui_disabled.cpp
@@ -14,8 +14,6 @@ static constexpr uint8_t kBrightness = 2;
 static constexpr uint8_t kBrightness = 16;
 #elif JL_IS_CONFIG(HAMMER)
 static constexpr uint8_t kBrightness = 255;
-#elif JL_IS_CONFIG(CREATURE)
-static constexpr uint8_t kBrightness = 16;
 #else
 static constexpr uint8_t kBrightness = 32;
 #endif

--- a/src/jazzlights/ui/ui_disabled.cpp
+++ b/src/jazzlights/ui/ui_disabled.cpp
@@ -6,14 +6,16 @@
 
 namespace jazzlights {
 namespace {
-#if JL_DEV
+#if defined(JL_BRIGHTNESS_CUSTOM)
+static constexpr uint8_t kBrightness = JL_BRIGHTNESS_CUSTOM;
+#elif JL_DEV
 static constexpr uint8_t kBrightness = 2;
 #elif JL_IS_CONFIG(STAFF)
 static constexpr uint8_t kBrightness = 16;
 #elif JL_IS_CONFIG(HAMMER)
 static constexpr uint8_t kBrightness = 255;
 #elif JL_IS_CONFIG(CREATURE)
-static constexpr uint8_t kBrightness = 96;
+static constexpr uint8_t kBrightness = 16;
 #else
 static constexpr uint8_t kBrightness = 32;
 #endif


### PR DESCRIPTION
- Move the RSSI decay and intensity calculation up to KnownCreatures class
- Make counter for intensity over threshold to make device wait 100 consecutive frames of low intensity (1s) before leaving rainbow