### PR TITLE
Add partition tables, .envrc, and VS Code config updates

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+source "$HOME/.platformio/penv/bin/activate"

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ SCRATCH.txt
 __pycache__/
 .gemini/
 GEMINI.md
+.clangd

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
+        "Jason2866.esp-decoder",
         "pioarduino.pioarduino-ide",
         "platformio.platformio-ide"
     ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -85,5 +85,9 @@
     "semaphore": "cpp",
     "span": "cpp",
     "stop_token": "cpp"
-  }
+  },
+  "clangd.arguments": [
+    "--compile-commands-dir=/Users/claudio/Projects/jazzlights/.pio/build/vest",
+    "--query-driver=/Users/claudio/.platformio/packages/toolchain-*/bin/*,/Users/claudio/.platformio/packages/tool-*/bin/*"
+  ]
 }

--- a/partitions/ESP32-wrover_4MB.csv
+++ b/partitions/ESP32-wrover_4MB.csv
@@ -1,0 +1,6 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x1A0000,
+app1,     app,  ota_1,   0x1B0000,0x1A0000,
+spiffs,   data, spiffs,  0x350000,0xB0000,

--- a/partitions/ESP32_16MB.csv
+++ b/partitions/ESP32_16MB.csv
@@ -1,0 +1,6 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x200000,
+app1,     app,  ota_1,   0x210000,0x200000,
+spiffs,   data, spiffs,  0x410000,0xBE0000,

--- a/partitions/ESP32_16MB_9MB_FS.csv
+++ b/partitions/ESP32_16MB_9MB_FS.csv
@@ -1,0 +1,8 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x300000,
+app1,     app,  ota_1,   0x310000,0x300000,
+spiffs,   data, spiffs,  0x610000,0x9E0000,
+coredump, data, coredump,,64K
+# to create/use ffat, see https://github.com/marcmerlin/esp32_fatfsimage

--- a/partitions/ESP32_2MB_noOTA.csv
+++ b/partitions/ESP32_2MB_noOTA.csv
@@ -1,0 +1,5 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,    20K,
+otadata,  data, ota,     0xe000,    8K,
+app0,     app,  ota_0,   0x10000,   1536K,
+spiffs,   data, spiffs,  0x190000,  384K,

--- a/partitions/ESP32_32MB.csv
+++ b/partitions/ESP32_32MB.csv
@@ -1,0 +1,7 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x300000,
+app1,     app,  ota_1,   0x310000,0x300000,
+spiffs,   data, spiffs,  0x610000,0x19E0000,
+coredump, data, coredump,,64K

--- a/partitions/ESP32_4MB_1MB_FS.csv
+++ b/partitions/ESP32_4MB_1MB_FS.csv
@@ -1,0 +1,6 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x180000,
+app1,     app,  ota_1,   0x190000,0x180000,
+spiffs,   data, spiffs,  0x310000,0xF0000,

--- a/partitions/ESP32_4MB_256KB_FS.csv
+++ b/partitions/ESP32_4MB_256KB_FS.csv
@@ -1,0 +1,7 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x1D0000,
+app1,     app,  ota_1,   0x1E0000,0x1D0000,
+spiffs,   data, spiffs,  0x3B0000,0x40000,
+coredump, data, coredump,,64K

--- a/partitions/ESP32_4MB_512KB_FS.csv
+++ b/partitions/ESP32_4MB_512KB_FS.csv
@@ -1,0 +1,7 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x1B0000,
+app1,     app,  ota_1,   0x1C0000,0x1B0000,
+spiffs,   data, spiffs,  0x370000,0x80000,
+coredump, data, coredump,,64K

--- a/partitions/ESP32_4MB_64KB_FS.csv
+++ b/partitions/ESP32_4MB_64KB_FS.csv
@@ -1,0 +1,6 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x1F0000,
+app1,     app,  ota_1,   0x200000,0x1F0000,
+spiffs,   data, spiffs,  0x3F0000,0x10000,

--- a/partitions/ESP32_4MB_700k_FS.csv
+++ b/partitions/ESP32_4MB_700k_FS.csv
@@ -1,0 +1,6 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x1A0000,
+app1,     app,  ota_1,   0x1B0000,0x1A0000,
+spiffs,   data, spiffs,  0x350000,0xB0000,

--- a/partitions/ESP32_8MB.csv
+++ b/partitions/ESP32_8MB.csv
@@ -1,0 +1,7 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x200000,
+app1,     app,  ota_1,   0x210000,0x200000,
+spiffs,   data, spiffs,  0x410000,0x3E0000,
+coredump, data, coredump,,64K

--- a/partitions/partitions-16MB_spiffs-tinyuf2.csv
+++ b/partitions/partitions-16MB_spiffs-tinyuf2.csv
@@ -1,0 +1,10 @@
+# ESP-IDF Partition Table
+# Name,   Type, SubType, Offset,  Size, Flags
+# bootloader.bin,,          0x1000, 32K
+# partition table,,         0x8000, 4K
+nvs,      data, nvs,      0x9000,  20K,
+otadata,  data, ota,      0xe000,  8K,
+ota_0,    app,  ota_0,   0x10000,  2048K,
+ota_1,    app,  ota_1,  0x210000,  2048K,
+uf2,      app,  factory,0x410000,  256K,
+spiffs,     data, spiffs,    0x450000,  11968K,

--- a/partitions/partitions-4MB_spiffs-tinyuf2.csv
+++ b/partitions/partitions-4MB_spiffs-tinyuf2.csv
@@ -1,0 +1,11 @@
+# ESP-IDF Partition Table
+# Name,   Type, SubType, Offset,  Size, Flags
+# bootloader.bin,,          0x1000, 32K
+# partition table,          0x8000, 4K
+
+nvs,      data, nvs,      0x9000,  20K,
+otadata,  data, ota,      0xe000,  8K,
+ota_0,    0,    ota_0,   0x10000,  1408K,
+ota_1,    0,    ota_1,  0x170000,  1408K,
+uf2,      app,  factory,0x2d0000,  256K,
+spiffs,   data, spiffs, 0x310000,  960K,

--- a/partitions/partitions-8MB_spiffs-tinyuf2.csv
+++ b/partitions/partitions-8MB_spiffs-tinyuf2.csv
@@ -1,0 +1,10 @@
+# ESP-IDF Partition Table
+# Name,   Type, SubType, Offset,  Size, Flags
+# bootloader.bin,,          0x1000, 32K
+# partition table,,         0x8000, 4K
+nvs,      data, nvs,      0x9000,  20K,
+otadata,  data, ota,      0xe000,  8K,
+ota_0,    app,    ota_0,   0x10000,  2048K,
+ota_1,    app,    ota_1,  0x210000,  2048K,
+uf2,      app,  factory,0x410000,  256K,
+spiffs,   data, spiffs,   0x450000,  3776K,


### PR DESCRIPTION
## Summary

- Add `.envrc` to auto-activate the PlatformIO virtualenv via direnv
- Add `.clangd` to `.gitignore`
- Add partition table CSV files for various ESP32 flash sizes (2MB–32MB, wrover, with/without tinyuf2)
- Add `Jason2866.esp-decoder` to VS Code extension recommendations
- Add `clangd.arguments` to VS Code settings for IntelliSense support

## Test plan

- [ ] Verify `.envrc` activates PlatformIO environment when entering the project directory
- [ ] Verify partition tables are valid for their respective board targets
- [ ] Verify VS Code picks up clangd config correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)