### PR TITLE
Sound effect: prevent additive sparkle from drifting toward white

### DIFF
--- a/src/jazzlights/effect/sound_effect.cpp
+++ b/src/jazzlights/effect/sound_effect.cpp
@@ -10,14 +10,14 @@ namespace {
 const TProgmemRGBPalette16* SoundReactivePaletteFromOurColorPalette(OurColorPalette ocp) {
   switch (ocp) {
     case OCPcloud: {
-      static const TProgmemRGBPalette16 SRCloudColors_p FL_PROGMEM = {CRGB::Blue,      CRGB::DarkBlue,
-                                                                      CRGB::DarkBlue,  CRGB::DarkBlue,
-                                                                      CRGB::DarkBlue,  CRGB::DarkBlue,
-                                                                      CRGB::DarkBlue,  CRGB::DarkBlue,
-                                                                      CRGB::Blue,      CRGB::DarkBlue,
-                                                                      CRGB::SkyBlue,   CRGB::SkyBlue,
-                                                                      CRGB::LightBlue, /*CRGB::White*/ CRGB::Blue,
-                                                                      CRGB::LightBlue, CRGB::SkyBlue};
+      static const TProgmemRGBPalette16 SRCloudColors_p FL_PROGMEM = {CRGB::Blue,        CRGB::DarkBlue,
+                                                                      CRGB::DarkBlue,    CRGB::DarkBlue,
+                                                                      CRGB::DarkBlue,    CRGB::DarkBlue,
+                                                                      CRGB::DarkBlue,    CRGB::DarkBlue,
+                                                                      CRGB::Blue,        CRGB::DarkBlue,
+                                                                      CRGB::SkyBlue,     CRGB::SkyBlue,
+                                                                      CRGB::MediumBlue,  /*CRGB::White*/ CRGB::Blue,
+                                                                      CRGB::MediumBlue,  CRGB::SkyBlue};
       return &SRCloudColors_p;
     }
     case OCPlava: {
@@ -263,11 +263,19 @@ ColorWithPalette SoundEffect::innerColor(const Frame& frame, const Pixel& px, So
   if (sparkleChance > 0 &&
       frame.predictableRandom->GetRandomNumberBetween(0, 5000) < static_cast<int32_t>(sparkleChance)) {
 #if 1
-    if (frame.predictableRandom->GetRandomByte() > 128) {
-      color.nscale8_video(192);        // Dim slightly to make room for...
-      color += state->brightestColor;  // ...a punch of the safe bass color
-    } else {
-      color.maximizeBrightness(200);  // Push to a safe ceiling
+    // Anti-white sparkle: multiplicative blend toward a brightened version
+    // of the current color, then cap the channel-sum so no pixel can read white.
+    {
+      CRGB sparkle = color;
+      sparkle.maximizeBrightness(220);
+      color = nblend(color, sparkle, 192);
+      uint16_t total = color.r + color.g + color.b;
+      if (total > 480) {
+        uint16_t scale = (480u * 256u) / total;
+        color.r = (color.r * scale) >> 8;
+        color.g = (color.g * scale) >> 8;
+        color.b = (color.b * scale) >> 8;
+      }
     }
 #else
     /*


### PR DESCRIPTION
Hey David - I dug into why I was still seeing white during sound-reactive mode after your `lesswhite` PR landed. Found three subtler additive-blend pathways in `sound_effect.cpp` that drift toward white on loud transients (especially with the Cloud palette). Wanted to share the analysis and a proposed fix in case it's useful - happy to discuss alternatives or close this if you'd rather take a different approach.

## The three white-producing pathways in the new sparkle code

The active sparkle block in `innerColor()` (lines 263-271, the `#if 1` branch):

```cpp
if (frame.predictableRandom->GetRandomByte() > 128) {
  color.nscale8_video(192);
  color += state->brightestColor;
} else {
  color.maximizeBrightness(200);
}

Path A: additive saturation toward white
color += state->brightestColor; is additive RGB blending — CRGB::operator+= clamps each channel at 255. For palettes with near-equal-channel entries (especially SRCloudColors_p containing LightBlue = (173, 216, 230)), brightestColor ends up around LightBlue itself. Adding LightBlue to a per-pixel LightBlue saturates all three channels and produces literal (255, 255, 255).

Path B: maximizeBrightness on dimmed background
The else-branch hits roughly 50% of pixels each frame. The background is dimmed via nscale8_video(16) to ~(11, 13, 14), then maximizeBrightness(200) rescales it preserving channel ratios → ~(157, 186, 200), near-white teal. This is a sparkle that shouldn't have been on a background pixel in the first place.

Path C: temporal accumulator drift
nblend(lastColor, color, blendAmount) at the bottom of innerColor() weights the previous frame at 75%. During sustained loud passages, repeated near-white sparkles in lastColor drift toward (255, 255, 255) within ~5 frames at 60fps, even if individual frames never quite reach pure white.

Proposed fix
Replace the additive sparkle with a multiplicative blend toward a brightened version of the current color (preserves hue better than additive)
Enforce a hard channel-sum cap of 480 (~63% of full white) - mathematically guarantees no pixel can read as white regardless of upstream math
Replace LightBlue with MediumBlue in SRCloudColors_p so even per-pixel values can't be near-white

Testing
Tested on M5CoreS3 dome controller (pio run -e audio_cores3 -t upload) with loud music, confirmed no more white pixels in Cloud, Forest, or Rainbow palettes during sustained transients. Sparkles still happen and are visibly brighter than the surrounding palette color, just hue-preserved.
Open to alternative tunings on the channel-sum cap value (480 was based on visual testing, could be tightened or relaxed).

---
The lesswhite PR removed the explicit CRGB::White flash on transients, but three subtler pathways still produced white-ish pixels during loud music with the Cloud, Forest, and Rainbow palettes:

1. The 'color += state->brightestColor' additive blend saturates all three channels when both colors share the same channel ratios. For SRCloudColors_p containing LightBlue, this produces literal white.

2. 'color.maximizeBrightness(200)' applied to a background pixel that was just dimmed via nscale8_video preserves near-equal channel ratios, producing a near-white sparkle.

3. The temporal nblend accumulator at the bottom of innerColor() retains values from previous frames; sustained loud passages drift the accumulator toward (255,255,255) within ~5 frames at 60fps.

Fix: replace the additive sparkle with a multiplicative blend toward a brightened version of the current color, then enforce a hard channel-sum cap of 480 (~63% of full white) to mathematically prevent any pixel from reading as white. Also replace LightBlue with MediumBlue in SRCloudColors_p so even the per-pixel value can no longer be near-white.

Tested on M5CoreS3 dome controller with loud music in Cloud, Forest, and Rainbow palettes - confirmed no more white pixels.